### PR TITLE
Update CSS for mobile

### DIFF
--- a/components/layout.module.css
+++ b/components/layout.module.css
@@ -9,10 +9,12 @@
     flex-direction: row;
 }
 
-
-.content {
-    margin: 0 5em;
+@media screen and (min-width: 640px) {
+    .content {
+        margin: 0 5em;
+    }
 }
+
 
 /* Add a black background color to the top navigation */
 .topnav {


### PR DESCRIPTION
The original CSS sets the margin of the .content class to 0 vertically and 5em horizontally, regardless of the screen size.

The updated code uses a media query, which makes the .content margin settings apply only when the screen width is at least 640px. On screens smaller than 640px, these settings won't apply, giving flexibility for mobile and responsive design.

![screencapture-what-if-scenarios-vercel-app-scenario-1-2023-07-26-11_10_17](https://github.com/VulcanWM/what-if/assets/719397/12b0f069-1685-4037-8ed6-fd403640166e)
![screencapture-what-if-scenarios-vercel-app-dashboard-2023-07-26-11_09_56](https://github.com/VulcanWM/what-if/assets/719397/e9d0585e-3ef8-44dd-95a3-919130da8357)
